### PR TITLE
Add simple dashboard page with dummy data

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import ProductListing from "./Pages/ProductListing.jsx";
 import Cart from "./Components/Table";
 import Groups2 from "./Pages/Groups2";
 import AuxiliaryListing from "./Pages/Auxiliaries";
+import Dashboard from "./Pages/Dashboard";
 
 const App = () => {
   // const fetchProducts = useCallback(async () => {
@@ -87,6 +88,7 @@ const App = () => {
         <Route path="/table" element={<Cart />} />
         <Route path="/Groups" element={<Groups2 />} />
         <Route path="/auxiliaries" element={<AuxiliaryListing />} />
+        <Route path="/dashboard" element={<Dashboard />} />
       </Routes>
     </HashRouter>
   );

--- a/src/Pages/Dashboard.jsx
+++ b/src/Pages/Dashboard.jsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { Box, Card, CardContent, Typography, Table, TableHead, TableBody, TableRow, TableCell, LinearProgress } from "@mui/material";
+
+const projects = [
+  {
+    id: 1,
+    customer: "ACME Corp",
+    projectName: "Factory A",
+    tender: "T001",
+    quotation: "Q1001",
+    panels: 5,
+    progress: 60,
+  },
+  {
+    id: 2,
+    customer: "Beta LLC",
+    projectName: "Warehouse B",
+    tender: "T002",
+    quotation: "Q1002",
+    panels: 3,
+    progress: 35,
+  },
+  {
+    id: 3,
+    customer: "Gamma Industries",
+    projectName: "Office Complex",
+    tender: "T003",
+    quotation: "Q1003",
+    panels: 8,
+    progress: 80,
+  },
+];
+
+const Dashboard = () => {
+  const totalPanels = projects.reduce((sum, p) => sum + p.panels, 0);
+
+  return (
+    <Box p={3}>
+      <Typography variant="h4" gutterBottom>
+        Master BOQ Dashboard
+      </Typography>
+
+      <Box display="flex" gap={2} mb={4}>
+        <Card sx={{ flex: 1 }}>
+          <CardContent>
+            <Typography variant="h6">Projects</Typography>
+            <Typography variant="h4">{projects.length}</Typography>
+          </CardContent>
+        </Card>
+        <Card sx={{ flex: 1 }}>
+          <CardContent>
+            <Typography variant="h6">Total Panels</Typography>
+            <Typography variant="h4">{totalPanels}</Typography>
+          </CardContent>
+        </Card>
+      </Box>
+
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Project Name</TableCell>
+            <TableCell>Customer</TableCell>
+            <TableCell>Tender</TableCell>
+            <TableCell>Quotation</TableCell>
+            <TableCell align="right">Panels</TableCell>
+            <TableCell>Progress</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {projects.map((p) => (
+            <TableRow key={p.id} hover>
+              <TableCell>{p.projectName}</TableCell>
+              <TableCell>{p.customer}</TableCell>
+              <TableCell>{p.tender}</TableCell>
+              <TableCell>{p.quotation}</TableCell>
+              <TableCell align="right">{p.panels}</TableCell>
+              <TableCell sx={{ width: 200 }}>
+                <Box display="flex" alignItems="center" gap={1}>
+                  <LinearProgress variant="determinate" value={p.progress} sx={{ flex: 1 }} />
+                  <Typography variant="body2">{p.progress}%</Typography>
+                </Box>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Box>
+  );
+};
+
+export default Dashboard;


### PR DESCRIPTION
## Summary
- add a new `Dashboard` page using Material UI components
- show dummy project data with progress indicators
- wire the dashboard route into `App.js`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847402a92bc832d9f73ef6734e6a611