### PR TITLE
feat: add dashboard header and summary card

### DIFF
--- a/src/Components/PageHeader.jsx
+++ b/src/Components/PageHeader.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import styled from 'styled-components';
+import BarChartIcon from '@mui/icons-material/BarChart';
+
+const Header = styled.h2`
+  display: flex;
+  align-items: center;
+  font-family: 'Lexend', sans-serif;
+  font-weight: 600;
+  font-size: 24px;
+  color: #0052CC;
+  margin-bottom: 1.5rem;
+
+  svg {
+    margin-right: 0.5rem;
+    color: #FF5630;
+  }
+`;
+
+const PageHeader = ({ title }) => (
+  <Header>
+    <BarChartIcon fontSize="inherit" />
+    {title}
+  </Header>
+);
+
+export default PageHeader;

--- a/src/Components/SummaryCard.jsx
+++ b/src/Components/SummaryCard.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Card = styled.div`
+  flex: 1;
+  padding: 1.5rem;
+  border-radius: 8px;
+  backdrop-filter: blur(8px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  background: rgba(255, 255, 255, 0.6);
+`;
+
+const Label = styled.div`
+  font-family: 'Lexend', sans-serif;
+  font-weight: 600;
+  font-size: 16px;
+  color: #0052CC;
+  margin-bottom: 0.5rem;
+`;
+
+const Number = styled.div`
+  font-family: 'Lexend', sans-serif;
+  font-weight: 600;
+  font-size: 24px;
+  color: #FF5630;
+`;
+
+const SummaryCard = ({ label, number }) => (
+  <Card>
+    <Label>{label}</Label>
+    <Number>{number}</Number>
+  </Card>
+);
+
+export default SummaryCard;

--- a/src/Pages/Dashboard.jsx
+++ b/src/Pages/Dashboard.jsx
@@ -8,6 +8,8 @@ import {
   TableCell,
   LinearProgress,
 } from "@mui/material";
+import PageHeader from "../Components/PageHeader";
+import SummaryCard from "../Components/SummaryCard";
 
 const projects = [
   {
@@ -46,36 +48,12 @@ const Container = styled.div`
   font-family: Lexend, sans-serif;
 `;
 
-const Title = styled.h2`
-  font-size: 2rem;
-  font-weight: 500;
-  margin-bottom: 1.5rem;
-`;
-
 const SummaryGrid = styled.div`
   display: flex;
   gap: 2rem;
   margin-bottom: 2rem;
 `;
 
-const InfoCard = styled.div`
-  background: #ffffff;
-  flex: 1;
-  padding: 1.5rem;
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-`;
-
-const CardLabel = styled.div`
-  font-size: 1rem;
-  font-weight: 500;
-  margin-bottom: 0.5rem;
-`;
-
-const CardNumber = styled.div`
-  font-size: 2rem;
-  font-weight: 500;
-`;
 
 const ProgressWrap = styled.div`
   display: flex;
@@ -100,17 +78,11 @@ const Dashboard = () => {
   return (
 
     <Container>
-      <Title>Master BOQ Dashboard</Title>
+      <PageHeader title="Master BOQ Dashboard" />
 
       <SummaryGrid>
-        <InfoCard>
-          <CardLabel>Projects</CardLabel>
-          <CardNumber>{projects.length}</CardNumber>
-        </InfoCard>
-        <InfoCard>
-          <CardLabel>Total Panels</CardLabel>
-          <CardNumber>{totalPanels}</CardNumber>
-        </InfoCard>
+        <SummaryCard label="Projects" number={projects.length} />
+        <SummaryCard label="Total Panels" number={totalPanels} />
       </SummaryGrid>
 
       <StyledTable size="small">


### PR DESCRIPTION
## Summary
- add `SummaryCard` component for showing project counts
- add `PageHeader` component with chart icon and brand colours
- update `Dashboard` to use these new components

## Testing
- `npm t` *(no tests found)*
- `npm run lint` *(fails: Missing script)*
- `npm run axe` *(fails: Missing script)*
- `npm run build` *(incomplete due to missing browserslist update)*

------
https://chatgpt.com/codex/tasks/task_e_68476ec2495c832d8026946acce35bb6